### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ WIP project developed [on Twitch](https://twitch.tv/skarab42). Follow [my channe
 
 # Features
 
-- In game Twitch authentification.
+- In game Twitch authentication.
 - Print a message in the HUD (center or top left).
 - Send a message to the brodcaster via Hugin (the crow in the tutorial). 
 - Spawn different entity (more or less aggressive, Troll, Boar, etc..) configurable in the game by the brodcaster.


### PR DESCRIPTION
> *Authentication* is the preferred form in English. The variant authentification is acceptable, but less common—it’s often used by non-native speakers who aren’t aware that it’s less idiomatic in English, because authentification (or an analogue) is the correct form (or at least widely accepted) in many eastern & western European languages

[Source](https://english.stackexchange.com/a/7845)